### PR TITLE
Later versions of cytoscape introduce incompatibilities

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,6 @@
   "name": "aip-interactions-viewer",
   "private": true,
   "dependencies": {
-    "cytoscape": "cytoscape/cytoscape.js#^2.3.9"
+    "cytoscape": "cytoscape/cytoscape.js#~2.3.x"
   }
 }


### PR DESCRIPTION
The bower.json definition for the cytoscape dependency allows the library to be updated to an incompatible version. Fixing the version to `~2.3.x` ensures that the cytoscape.js version will be compatible. 
